### PR TITLE
feat: User API 구현 및 관련 로직 추가

### DIFF
--- a/src/main/java/com/zerobase/storereservation/config/SecurityConfig.java
+++ b/src/main/java/com/zerobase/storereservation/config/SecurityConfig.java
@@ -1,0 +1,19 @@
+package com.zerobase.storereservation.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth.anyRequest()
+                        .permitAll()
+                );
+        return http.build();
+    }
+}

--- a/src/main/java/com/zerobase/storereservation/controller/UserController.java
+++ b/src/main/java/com/zerobase/storereservation/controller/UserController.java
@@ -1,0 +1,29 @@
+package com.zerobase.storereservation.controller;
+
+import com.zerobase.storereservation.dto.UserDto;
+import com.zerobase.storereservation.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping
+    public ResponseEntity<UserDto.Response> createUser(
+            @RequestBody UserDto.CreateRequest request
+    ) {
+        return ResponseEntity.ok(userService.createUser(request));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<UserDto.Response> getUser(
+            @PathVariable Long id
+    ) {
+        return ResponseEntity.ok(userService.getUserById(id));
+    }
+}

--- a/src/main/java/com/zerobase/storereservation/dto/UserDto.java
+++ b/src/main/java/com/zerobase/storereservation/dto/UserDto.java
@@ -1,0 +1,22 @@
+package com.zerobase.storereservation.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+public class UserDto {
+
+    @Data
+    public static class CreateRequest {
+        private String username;
+        private String password;
+        private String role;
+    }
+
+    @Data
+    @Builder
+    public static class Response{
+        private Long id;
+        private String username;
+        private String role;
+    }
+}

--- a/src/main/java/com/zerobase/storereservation/repository/UserRepository.java
+++ b/src/main/java/com/zerobase/storereservation/repository/UserRepository.java
@@ -4,4 +4,5 @@ import com.zerobase.storereservation.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByUsername(String username);
 }

--- a/src/main/java/com/zerobase/storereservation/service/UserService.java
+++ b/src/main/java/com/zerobase/storereservation/service/UserService.java
@@ -1,0 +1,48 @@
+package com.zerobase.storereservation.service;
+
+import com.zerobase.storereservation.dto.UserDto;
+import com.zerobase.storereservation.entity.User;
+import com.zerobase.storereservation.exception.CustomException;
+import com.zerobase.storereservation.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import static com.zerobase.storereservation.exception.ErrorCode.USER_ALREADY_EXISTS;
+import static com.zerobase.storereservation.exception.ErrorCode.USER_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public UserDto.Response createUser(UserDto.CreateRequest request) {
+
+        if (userRepository.existsByUsername(request.getUsername())) {
+            throw new CustomException(USER_ALREADY_EXISTS);
+        }
+
+        User user = User.builder()
+                .username(request.getUsername())
+                .password(request.getPassword())
+                .role(request.getRole())
+                .build();
+
+        user = userRepository.save(user);
+        return UserDto.Response.builder()
+                .id(user.getId())
+                .username(user.getUsername())
+                .role(user.getRole())
+                .build();
+    }
+
+    public UserDto.Response getUserById(Long id) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        return UserDto.Response.builder()
+                .id(user.getId())
+                .username(user.getUsername())
+                .role(user.getRole())
+                .build();
+    }
+}


### PR DESCRIPTION
- UserController, UserService, UserDto, UserRepository 작성
- 사용자 등록(createUser) 및 조회(getUserById) API 구현
- 중복된 사용자 이름 확인 로직 추가
  - UserRepository.existsByUsername 메서드 활용
  - ErrorCode.USER_ALREADY_EXISTS 예외 처리 적용
- SecurityConfig 설정 추가 (모든 요청 허용 및 CSRF 비활성화)