### PR TITLE
feat(store-management): 매장 관리 기능 구현 완료

### DIFF
--- a/src/main/java/com/zerobase/storereservation/controller/StoreController.java
+++ b/src/main/java/com/zerobase/storereservation/controller/StoreController.java
@@ -25,4 +25,22 @@ public class StoreController {
             @PathVariable Long id) {
         return ResponseEntity.ok(storeService.getStoreById(id));
     }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<StoreDto.Response> updateStore(
+            @PathVariable Long id,
+            @RequestBody StoreDto.CreateRequest request
+    ) {
+        return ResponseEntity.ok(storeService.updateStore(id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteStore(
+            @PathVariable Long id
+    ) {
+        storeService.deleteStore(id);
+        return ResponseEntity.noContent().build();
+    }
+
+
 }

--- a/src/main/java/com/zerobase/storereservation/dto/StoreDto.java
+++ b/src/main/java/com/zerobase/storereservation/dto/StoreDto.java
@@ -2,6 +2,7 @@ package com.zerobase.storereservation.dto;
 
 import lombok.Builder;
 import lombok.Data;
+import lombok.Getter;
 
 public class StoreDto {
 

--- a/src/main/java/com/zerobase/storereservation/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/storereservation/exception/ErrorCode.java
@@ -13,6 +13,8 @@ public enum ErrorCode {
 
     // Store Error
     STORE_NOT_FOUND(HttpStatus.BAD_REQUEST, "STORE-001", "상점을 찾을 수 없습니다."),
+    UNAUTHORIZED_ACTION(HttpStatus.FORBIDDEN, "STORE-002", "상점 소유자가 아니어서 권한이 없습니다."),
+
     // Reservation Error
     RESERVATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "RESERVATION-001", "예약을 찾을 수 없습니다."),
 

--- a/src/test/java/com/zerobase/storereservation/repository/ReservationRepositoryTest.java
+++ b/src/test/java/com/zerobase/storereservation/repository/ReservationRepositoryTest.java
@@ -5,6 +5,7 @@ import com.zerobase.storereservation.entity.Reservation;
 import com.zerobase.storereservation.entity.Store;
 import com.zerobase.storereservation.entity.User;
 import com.zerobase.storereservation.entity.constants.ReservationStatus;
+import com.zerobase.storereservation.entity.constants.Role;
 import com.zerobase.storereservation.exception.CustomException;
 import com.zerobase.storereservation.exception.ErrorCode;
 import com.zerobase.storereservation.service.ReservationService;
@@ -41,7 +42,7 @@ class ReservationRepositoryTest {
         User user = User.builder()
                 .username("customer")
                 .password("password")
-                .role("CUSTOMER")
+                .role(Role.CUSTOMER)
                 .build();
         userRepository.save(user);
 

--- a/src/test/java/com/zerobase/storereservation/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/zerobase/storereservation/repository/ReviewRepositoryTest.java
@@ -3,6 +3,7 @@ package com.zerobase.storereservation.repository;
 import com.zerobase.storereservation.entity.Review;
 import com.zerobase.storereservation.entity.Store;
 import com.zerobase.storereservation.entity.User;
+import com.zerobase.storereservation.entity.constants.Role;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,6 +13,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+import static com.zerobase.storereservation.entity.constants.Role.CUSTOMER;
 import static org.junit.jupiter.api.Assertions.*;
 
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -34,7 +36,7 @@ class ReviewRepositoryTest {
         User user = User.builder()
                 .username("reviewer")
                 .password("password")
-                .role("CUSTOMER")
+                .role(CUSTOMER)
                 .build();
         userRepository.save(user);
 

--- a/src/test/java/com/zerobase/storereservation/repository/StoreRepositoryTest.java
+++ b/src/test/java/com/zerobase/storereservation/repository/StoreRepositoryTest.java
@@ -2,6 +2,7 @@ package com.zerobase.storereservation.repository;
 
 import com.zerobase.storereservation.entity.Store;
 import com.zerobase.storereservation.entity.User;
+import com.zerobase.storereservation.entity.constants.Role;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,7 +30,7 @@ class StoreRepositoryTest {
         User owner = User.builder()
                 .username("owner")
                 .password("password")
-                .role("PARTNER")
+                .role(Role.PARTNER)
                 .build();
         userRepository.save(owner);
 

--- a/src/test/java/com/zerobase/storereservation/repository/UserRepositoryTest.java
+++ b/src/test/java/com/zerobase/storereservation/repository/UserRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.zerobase.storereservation.repository;
 
 import com.zerobase.storereservation.entity.User;
+import com.zerobase.storereservation.entity.constants.Role;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,7 +26,7 @@ class UserRepositoryTest {
         User user = User.builder()
                 .username("test")
                 .password("testPassword")
-                .role("CUSTOMER")
+                .role(Role.CUSTOMER)
                 .build();
 
         //when

--- a/src/test/java/com/zerobase/storereservation/service/StoreServiceTest.java
+++ b/src/test/java/com/zerobase/storereservation/service/StoreServiceTest.java
@@ -1,0 +1,259 @@
+package com.zerobase.storereservation.service;
+
+import com.zerobase.storereservation.dto.StoreDto;
+import com.zerobase.storereservation.entity.Store;
+import com.zerobase.storereservation.entity.User;
+import com.zerobase.storereservation.exception.CustomException;
+import com.zerobase.storereservation.exception.ErrorCode;
+import com.zerobase.storereservation.repository.StoreRepository;
+import com.zerobase.storereservation.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class StoreServiceTest {
+
+    @InjectMocks
+    private StoreService storeService;
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("상점 등록 성공")
+    void createStoreSuccess() {
+        //given
+        StoreDto.CreateRequest request = new StoreDto.CreateRequest();
+        request.setName("Test Store");
+        request.setLocation("Test Location");
+        request.setDescription("Test Description");
+        request.setOwnerId(1L);
+
+        User mockUser = User.builder().id(1L).build();
+
+        Store mockStore = Store.builder()
+                .id(1L)
+                .name("Test Store")
+                .location("Test Location")
+                .description("Test Description")
+                .owner(mockUser)
+                .build();
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+        when(storeRepository.save(any(Store.class))).thenReturn(mockStore);
+
+        //when
+        StoreDto.Response response = storeService.createStore(request);
+
+        //then
+        assertNotNull(response);
+        assertEquals("Test Store", response.getName());
+        assertEquals("Test Location", response.getLocation());
+        assertEquals("Test Description", response.getDescription());
+        verify(userRepository, times(1)).findById(1L);
+        verify(storeRepository, times(1)).save(any(Store.class));
+    }
+
+    @Test
+    @DisplayName("상점 등록 실패 - 소유자 없음")
+    void createStoreUserNotFound() {
+        //given
+        StoreDto.CreateRequest request = new StoreDto.CreateRequest();
+        request.setOwnerId(999L);
+
+        when(userRepository.findById(999L)).thenReturn(Optional.empty());
+        //when&then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> storeService.createStore(request));
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+        verify(storeRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("상점 조회 성공")
+    void getStoreByIdSuccess() {
+        //given
+        Long storeId = 1L;
+        User mockUser = User.builder().id(1L).build();
+        Store mockStore = Store.builder()
+                .id(storeId)
+                .name("Test Store")
+                .location("Test Location")
+                .description("Test Description")
+                .owner(mockUser)
+                .build();
+
+        when(storeRepository.findById(storeId))
+                .thenReturn(Optional.of(mockStore));
+
+        //when
+        StoreDto.Response response = storeService.getStoreById(storeId);
+
+        //then
+        assertNotNull(response);
+        assertEquals("Test Store", response.getName());
+        verify(storeRepository, times(1)).findById(storeId);
+    }
+
+    @Test
+    @DisplayName("상점 조회 실패 - 상점 없음")
+    void getStoreByIdNotFound() {
+        //given
+        Long storeId = 999L;
+        when(storeRepository.findById(999L)).thenReturn(Optional.empty());
+
+        //when&then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> storeService.getStoreById(storeId));
+        assertEquals(ErrorCode.STORE_NOT_FOUND, exception.getErrorCode());
+        verify(storeRepository, times(1)).findById(storeId);
+    }
+
+    @Test
+    @DisplayName("상점 수정 성공")
+    void updateStoreSuccess() {
+        //given
+        Long storeId = 1L;
+        StoreDto.CreateRequest request = new StoreDto.CreateRequest();
+        request.setName("Update Store");
+        request.setLocation("Update Location");
+        request.setDescription("Update Description");
+
+        User mockUser = User.builder().id(1L).build();
+        Store mockStore = Store.builder()
+                .id(storeId)
+                .name("Original Store")
+                .location("Original Location")
+                .description("Original Description")
+                .owner(mockUser)
+                .build();
+
+        mockSecurityContext(mockUser);
+
+        when(storeRepository.findById(storeId)).thenReturn(Optional.of(mockStore));
+        when(storeRepository.save(any(Store.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        //when
+        StoreDto.Response response = storeService.updateStore(storeId, request);
+
+        //then
+        assertNotNull(response);
+        assertEquals("Update Store", response.getName());
+        assertEquals("Update Location", response.getLocation());
+        assertEquals("Update Description", response.getDescription());
+        verify(storeRepository, times(1)).findById(storeId);
+        verify(storeRepository, times(1)).save(any(Store.class));
+    }
+
+    @Test
+    @DisplayName("상점 수정 실패 - 권한 없음")
+    void updateStoreUnauthorized() {
+        //given
+        Long storeId = 1L;
+        StoreDto.CreateRequest request = new StoreDto.CreateRequest();
+        request.setName("Unauthorized Update");
+
+        User mockOwner = User.builder().id(1L).build();
+        User mockUser = User.builder().id(2L).build();
+
+        Store mockStore = Store.builder()
+                .id(storeId)
+                .name("Original Store")
+                .owner(mockOwner)
+                .build();
+
+        when(storeRepository.findById(storeId)).thenReturn(Optional.of(mockStore));
+        mockSecurityContext(mockUser);
+
+        //when&then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> storeService.updateStore(storeId, request));
+        assertEquals(ErrorCode.UNAUTHORIZED_ACTION, exception.getErrorCode());
+        verify(storeRepository, times(1)).findById(storeId);
+        verify(storeRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("상점 삭제 성공")
+    void deleteStoreSuccess() {
+        //given
+        Long storeId = 1L;
+        User mockUser = User.builder().id(1L).build();
+        Store mockStore = Store.builder()
+                .id(storeId)
+                .name("Test Store")
+                .owner(mockUser)
+                .build();
+
+        when(storeRepository.findById(storeId)).thenReturn(Optional.of(mockStore));
+        mockSecurityContext(mockUser);
+        when(storeRepository.findById(storeId)).thenReturn(Optional.of(mockStore));
+
+        //when
+        storeService.deleteStore(storeId);
+
+        //then
+        verify(storeRepository, times(1)).findById(storeId);
+        verify(storeRepository, times(1)).delete(mockStore);
+    }
+
+
+
+    @Test
+    void deleteStoreUnauthorized() {
+        //given
+        Long storeId = 1L;
+        User mockOwner = User.builder().id(1L).build();
+        User mockUser = User.builder().id(2L).build();
+
+        Store mockStore = Store.builder()
+                .id(storeId)
+                .name("Test Store")
+                .owner(mockOwner)
+                .build();
+
+        when(storeRepository.findById(storeId)).thenReturn(Optional.of(mockStore));
+        mockSecurityContext(mockUser);
+
+        //when&then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> storeService.deleteStore(storeId));
+        assertEquals(ErrorCode.UNAUTHORIZED_ACTION, exception.getErrorCode());
+        verify(storeRepository, times(1)).findById(storeId);
+        verify(storeRepository, never()).delete(any());
+    }
+
+    private void mockSecurityContext(User mockUser) {
+        Authentication mockAuth = mock(Authentication.class);
+        SecurityContext mockSecurityContext = mock(SecurityContext.class);
+        when(mockSecurityContext.getAuthentication()).thenReturn(mockAuth);
+        when(mockAuth.getPrincipal()).thenReturn(mockUser);
+        SecurityContextHolder.setContext(mockSecurityContext);
+    }
+}


### PR DESCRIPTION
- 매장 등록, 조회, 수정, 삭제 API 구현
  - `/api/stores` 경로로 매장 관리 기능 제공
  - 등록: POST /api/stores
  - 조회: GET /api/stores/{id}
  - 수정: PUT /api/stores/{id}
  - 삭제: DELETE /api/stores/{id}
- 매장 소유자 검증 로직 추가
  - SecurityContextHolder를 활용하여 현재 인증된 사용자를 확인
  - 매장 소유자가 아닌 경우 CustomException을 활용해 UNAUTHORIZED_ACTION 처리
- CustomException에 UNAUTHORIZED_ACTION 에러 코드 추가
  - 권한이 없는 작업 시 403 응답
- Service와 Controller에서 DTO(StoreDto)를 통해 데이터 전송 및 응답 처리
  - CreateRequest: 매장 등록 및 수정 요청 처리
  - Response: 매장 조회 응답 처리

- 매장 관리 관련 테스트 작성 및 성공 확인
  - StoreServiceTest:
    - 매장 등록 성공/실패 (소유자 없음)
    - 매장 조회 성공/실패 (매장 없음)
    - 매장 수정 성공/실패 (권한 없음)
    - 매장 삭제 성공/실패 (권한 없음)
  - SecurityContextHolder를 활용한 Mock 테스트 진행

관련 작업:
- 매장 CRUD 구현
- 매장 소유자 검증 로직 추가
- 매장 관리 테스트 코드 작성