### PR TITLE
feat(reservation): 예약 취소 및 도착 확인 기능 구현

### DIFF
--- a/src/main/java/com/zerobase/storereservation/controller/ReservationController.java
+++ b/src/main/java/com/zerobase/storereservation/controller/ReservationController.java
@@ -26,4 +26,19 @@ public class ReservationController {
     ) {
         return ResponseEntity.ok(reservationService.getReservationById(id));
     }
+
+    @PostMapping("/{id}/cancel")
+    public ResponseEntity<ReservationDto.Response> cancelReservation(
+            @PathVariable Long id
+    ) {
+        return ResponseEntity.ok(reservationService.cancelReservation(id));
+    }
+
+    @PostMapping("/{id}/check-arrival")
+    public ResponseEntity<ReservationDto.CheckArrivalResponse> checkArrival(
+            @PathVariable Long id,
+            @RequestBody ReservationDto.CheckArrivalRequest request
+    ) {
+        return ResponseEntity.ok(reservationService.checkArrival(id, request.getArrivalTime()));
+    }
 }

--- a/src/main/java/com/zerobase/storereservation/dto/ReservationDto.java
+++ b/src/main/java/com/zerobase/storereservation/dto/ReservationDto.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.zerobase.storereservation.entity.constants.ReservationStatus;
 import lombok.Builder;
 import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
 
@@ -30,4 +31,22 @@ public class ReservationDto {
 
         private ReservationStatus status;
     }
+
+    @Data
+    public static class CancelRequest {
+        private String reason;  // 취소 사유
+    }
+
+    @Data
+    public static class CheckArrivalRequest {
+        private LocalDateTime arrivalTime;
+    }
+
+    @Data
+    @Builder
+    public static class CheckArrivalResponse {
+        private Long reservationId;
+        private boolean arrived;
+    }
+
 }

--- a/src/main/java/com/zerobase/storereservation/entity/Reservation.java
+++ b/src/main/java/com/zerobase/storereservation/entity/Reservation.java
@@ -2,15 +2,13 @@ package com.zerobase.storereservation.entity;
 
 import com.zerobase.storereservation.entity.constants.ReservationStatus;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/src/main/java/com/zerobase/storereservation/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/storereservation/exception/ErrorCode.java
@@ -17,7 +17,7 @@ public enum ErrorCode {
 
     // Reservation Error
     RESERVATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "RESERVATION-001", "예약을 찾을 수 없습니다."),
-
+    ALREADY_CANCELLED(HttpStatus.BAD_REQUEST, "RESERVATION-002", "이미 취소된 예약입니다."),
     //Review Error
     REVIEW_NOT_FOUND(HttpStatus.BAD_REQUEST, "REVIEW-001", "리뷰가 존재하지 않습니다.");
 

--- a/src/test/java/com/zerobase/storereservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/zerobase/storereservation/service/ReservationServiceTest.java
@@ -9,6 +9,8 @@ import com.zerobase.storereservation.exception.CustomException;
 import com.zerobase.storereservation.repository.ReservationRepository;
 import com.zerobase.storereservation.repository.StoreRepository;
 import com.zerobase.storereservation.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -17,11 +19,12 @@ import org.mockito.MockitoAnnotations;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+import static com.zerobase.storereservation.entity.constants.ReservationStatus.CANCELLED;
 import static com.zerobase.storereservation.entity.constants.ReservationStatus.CONFIRMED;
-import static com.zerobase.storereservation.exception.ErrorCode.STORE_NOT_FOUND;
+import static com.zerobase.storereservation.exception.ErrorCode.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 class ReservationServiceTest {
 
@@ -37,11 +40,13 @@ class ReservationServiceTest {
     @InjectMocks
     private ReservationService reservationService;
 
-    public ReservationServiceTest() {
+    @BeforeEach
+    void setUp() {
         MockitoAnnotations.openMocks(this);
     }
 
     @Test
+    @DisplayName("예약 생성 성공")
     void createReservationSuccess() {
         // given
         Store store = Store.builder()
@@ -91,6 +96,7 @@ class ReservationServiceTest {
     }
 
     @Test
+    @DisplayName("예약 생성 실패 - 상점 없음")
     void createReservationStoreNotFound() {
         // given
         when(storeRepository.findById(1L)).thenReturn(Optional.empty());
@@ -108,6 +114,7 @@ class ReservationServiceTest {
     }
 
     @Test
+    @DisplayName("예약 조회 성공")
     void getReservationByIdSuccess() {
         //given
         Store store = Store.builder()
@@ -140,5 +147,179 @@ class ReservationServiceTest {
         assertEquals(1L, response.getUserId());
         assertEquals(LocalDateTime.of(2024, 12, 1, 10, 30), response.getReservedAt());
         assertEquals(CONFIRMED, response.getStatus());
+    }
+
+    @Test
+    @DisplayName("예약 취소 성공")
+    void cancelReservationSuccess() {
+        //given
+        Store mockStore = Store.builder()
+                .id(1L)
+                .name("Test Store")
+                .build();
+
+        User mockUser = User.builder()
+                .id(1L)
+                .username("Test User")
+                .build();
+
+        Reservation existingReservation = Reservation.builder()
+                .id(1L)
+                .store(mockStore)
+                .user(mockUser)
+                .status(CONFIRMED)
+                .reservedAt(LocalDateTime.of(2024, 12, 1, 10, 30))
+                .build();
+
+        when(reservationRepository.findById(1L))
+                .thenReturn(Optional.of(existingReservation));
+
+        //when
+        ReservationDto.Response response = reservationService.cancelReservation(1L);
+
+        //then
+        assertNotNull(response);
+        assertEquals(1L, response.getId());
+        assertEquals(CANCELLED, response.getStatus());
+        verify(reservationRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    @DisplayName("예약 취소 실패 - 예약 없음")
+    void cancelReservationStoreNotFound() {
+        //given
+        when(reservationRepository.findById(1L)).thenReturn(Optional.empty());
+
+        //when&then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> reservationService.cancelReservation(1L));
+        assertEquals(RESERVATION_NOT_FOUND, exception.getErrorCode());
+        verify(reservationRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    @DisplayName("예약 취소 실패 - 이미 취소된 예약")
+    void cancelReservationAlreadyCancelled() {
+        //given
+        Reservation reservation = Reservation.builder()
+                .id(1L)
+                .status(CANCELLED)
+                .reservedAt(LocalDateTime.of(2024, 12, 1, 10, 30))
+                .build();
+
+        when(reservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
+
+        //when&then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> reservationService.cancelReservation(1L));
+        assertEquals(ALREADY_CANCELLED, exception.getErrorCode());
+        verify(reservationRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    @DisplayName("도착 확인 성공 - 도착 10분 전")
+    void checkArrivalSuccess() {
+        //given
+        Reservation reservation = Reservation.builder()
+                .id(1L)
+                .reservedAt(LocalDateTime.of(2024, 12, 1, 10, 30))
+                .status(CONFIRMED)
+                .build();
+
+        when(reservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
+
+        ReservationDto.CheckArrivalRequest request =
+                new ReservationDto.CheckArrivalRequest();
+        request.setArrivalTime(LocalDateTime.of(2024, 12, 1, 10, 25));
+
+        //when
+        ReservationDto.CheckArrivalResponse response =
+                reservationService.checkArrival(1L, request.getArrivalTime());
+
+        //then
+        assertNotNull(response);
+        assertTrue(response.isArrived());
+        assertEquals(1L, response.getReservationId());
+    }
+
+    @Test
+    @DisplayName("도착 확인 실패 - 예약 없음")
+    void checkArrivalReservationNotFound() {
+        //given
+        when(reservationRepository.findById(1L)).thenReturn(Optional.empty());
+
+        //when&then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> reservationService.checkArrival(1L, LocalDateTime.now()));
+        assertEquals(RESERVATION_NOT_FOUND, exception.getErrorCode());
+        verify(reservationRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    @DisplayName("도착 확인 실패 - 예약 취소됨")
+    void checkArrivalAlreadyCancelled() {
+        //given
+        Reservation reservation = Reservation.builder()
+                .id(1L)
+                .status(CANCELLED)
+                .reservedAt(LocalDateTime.of(2024, 12, 1, 10, 30))
+                .build();
+
+        when(reservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
+
+        //when&then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> reservationService.checkArrival(1L, LocalDateTime.of(
+                        2024, 12, 1, 10, 21
+                )));
+        assertEquals(ALREADY_CANCELLED, exception.getErrorCode());
+        verify(reservationRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    @DisplayName("도착 확인 실패 - 예약 시간 보다 늦게 도착")
+    void checkArrivalTooLate() {
+        //given
+        Reservation reservation = Reservation.builder()
+                .id(1L)
+                .reservedAt(LocalDateTime.of(2024, 12, 1, 10, 30))
+                .status(CONFIRMED)
+                .build();
+
+        when(reservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
+
+        LocalDateTime lateArrival = LocalDateTime.of(2024, 12, 1, 10, 35);
+
+        //when
+        ReservationDto.CheckArrivalResponse response =
+                reservationService.checkArrival(1L, lateArrival);
+
+        //then
+        assertNotNull(response);
+        assertFalse(response.isArrived());
+        verify(reservationRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    @DisplayName("도착 확인 실패 - 예약 시간보다 10분 이르게 도착")
+    void checkArrivalTooEarly() {
+        //given
+        Reservation reservation = Reservation.builder()
+                .id(1L)
+                .status(CONFIRMED)
+                .reservedAt(LocalDateTime.of(2024, 12, 1, 10, 30))
+                .build();
+
+        when(reservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
+        LocalDateTime earlyArrival = LocalDateTime.of(2024, 12, 1, 10, 19);
+
+        //when
+        ReservationDto.CheckArrivalResponse response =
+                reservationService.checkArrival(1L, earlyArrival);
+
+        //then
+        assertNotNull(response);
+        assertFalse(response.isArrived());
+        verify(reservationRepository, times(1)).findById(1L);
     }
 }


### PR DESCRIPTION
- 예약 취소 API 추가 및 관련 로직 작성
- 도착 확인 API 추가 (10분 전~예약 시간까지 도착 체크)
- 예약 상태가 CANCELLED인 경우 예외 처리
- 다양한 테스트 케이스 작성 및 통과:
  - 예약 생성, 취소 성공/실패
  - 도착 확인 성공/실패 케이스 (취소된 예약, 너무 일찍/늦게 도착한 경우 등)
- ReservationDto에 CheckArrival 관련 클래스 추가
- 관련 테스트 전부 통과