### PR TITLE
feat(review): 리뷰 api 수정 및 추가, 테스트 코드 작성

### DIFF
--- a/src/main/java/com/zerobase/storereservation/controller/ReviewController.java
+++ b/src/main/java/com/zerobase/storereservation/controller/ReviewController.java
@@ -29,11 +29,21 @@ public class ReviewController {
         return ResponseEntity.ok(reviewService.getReviewsByStore(storeId));
     }
 
+    @PutMapping("/{reviewId}")
+    public ResponseEntity<ReviewDto.Response> updateReview(
+            @PathVariable Long reviewId,
+            @RequestParam Long userId,
+            @RequestBody ReviewDto.UpdateRequest request
+    ) {
+        return ResponseEntity.ok(reviewService.updateReview(reviewId, userId, request));
+    }
+
     @DeleteMapping("/{reviewId}")
     public ResponseEntity<ReviewDto.Response> deleteReview(
-            @PathVariable Long reviewId
+            @PathVariable Long reviewId,
+            @RequestParam Long userId
     ) {
-        reviewService.deleteReview(reviewId);
+        reviewService.deleteReview(reviewId, userId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/zerobase/storereservation/dto/ReviewDto.java
+++ b/src/main/java/com/zerobase/storereservation/dto/ReviewDto.java
@@ -12,6 +12,7 @@ public class ReviewDto {
         private Long storeId;
         private Long userId;
         private String content;
+        private int rating;
     }
 
     @Data
@@ -21,6 +22,13 @@ public class ReviewDto {
         private Long storeId;
         private Long userId;
         private String content;
+        private int rating;
         private LocalDateTime createdAt;
+    }
+
+    @Data
+    public static class UpdateRequest {
+        private String content;
+        private int rating;
     }
 }

--- a/src/main/java/com/zerobase/storereservation/entity/Review.java
+++ b/src/main/java/com/zerobase/storereservation/entity/Review.java
@@ -29,5 +29,8 @@ public class Review {
     private String content;             //리뷰 내용
 
     @Column(nullable = false)
+    private int rating;                 // 평점
+
+    @Column(nullable = false)
     private LocalDateTime createdAt;    // 리뷰 작성 시간
 }

--- a/src/main/java/com/zerobase/storereservation/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/storereservation/exception/ErrorCode.java
@@ -18,8 +18,10 @@ public enum ErrorCode {
     // Reservation Error
     RESERVATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "RESERVATION-001", "예약을 찾을 수 없습니다."),
     ALREADY_CANCELLED(HttpStatus.BAD_REQUEST, "RESERVATION-002", "이미 취소된 예약입니다."),
+
     //Review Error
-    REVIEW_NOT_FOUND(HttpStatus.BAD_REQUEST, "REVIEW-001", "리뷰가 존재하지 않습니다.");
+    REVIEW_NOT_FOUND(HttpStatus.BAD_REQUEST, "REVIEW-001", "리뷰가 존재하지 않습니다."),
+    INVALID_RATING(HttpStatus.BAD_REQUEST, "REVIEW-002", "평점은 1에서 5 사이의 값이어야 합니다.");
 
     private final HttpStatus httpStatus;
     private final String code;      // 에러 코드를 숫자로 변환하면 클라이언트에서 파싱하기 편함

--- a/src/main/java/com/zerobase/storereservation/service/ReviewService.java
+++ b/src/main/java/com/zerobase/storereservation/service/ReviewService.java
@@ -5,11 +5,13 @@ import com.zerobase.storereservation.entity.Review;
 import com.zerobase.storereservation.entity.Store;
 import com.zerobase.storereservation.entity.User;
 import com.zerobase.storereservation.exception.CustomException;
+import com.zerobase.storereservation.exception.ErrorCode;
 import com.zerobase.storereservation.repository.ReviewRepository;
 import com.zerobase.storereservation.repository.StoreRepository;
 import com.zerobase.storereservation.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -26,6 +28,10 @@ public class ReviewService {
     private final StoreRepository storeRepository;
 
     public ReviewDto.Response createReview(ReviewDto.CreateRequest request) {
+        if(request.getRating() < 1 || request.getRating() > 5) {
+            throw new CustomException(ErrorCode.INVALID_RATING);
+        }
+
         Store store = storeRepository.findById(request.getStoreId())
                 .orElseThrow(() -> new CustomException(STORE_NOT_FOUND));
 
@@ -50,6 +56,7 @@ public class ReviewService {
                 .build();
     }
 
+    @Transactional(readOnly = true)
     public List<ReviewDto.Response> getReviewsByStore(Long storeId) {
         List<Review> reviews = reviewRepository.findByStoreId(storeId);
         return reviews.stream()
@@ -57,16 +64,50 @@ public class ReviewService {
                         .id(review.getId())
                         .storeId(review.getStore().getId())
                         .userId(review.getUser().getId())
+                        .rating(review.getRating())
                         .content(review.getContent())
                         .createdAt(review.getCreatedAt())
                         .build())
                 .collect(Collectors.toList());
     }
 
-    public void deleteReview(Long reviewId) {
-        if (!reviewRepository.existsById(reviewId)) {
-            throw new CustomException(REVIEW_NOT_FOUND);
+    @Transactional
+    public void deleteReview(Long reviewId, Long userId) {
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new CustomException(REVIEW_NOT_FOUND));
+
+        Long storeOwnerId = review.getStore().getOwner().getId();
+        Long reviewerId = review.getUser().getId();
+
+        if (!storeOwnerId.equals(userId) && !reviewerId.equals(userId)) {
+            throw new CustomException(UNAUTHORIZED_ACTION);
         }
         reviewRepository.deleteById(reviewId);
+    }
+
+    @Transactional
+    public ReviewDto.Response updateReview(Long reviewId, Long userId, ReviewDto.UpdateRequest request) {
+        if(request.getRating() < 1 || request.getRating() > 5) {
+            throw new CustomException(ErrorCode.INVALID_RATING);
+        }
+
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new CustomException(REVIEW_NOT_FOUND));
+
+        if(!review.getUser().getId().equals(userId)) {
+            throw new CustomException(UNAUTHORIZED_ACTION);
+        }
+
+        review.setContent(request.getContent());
+        review.setRating(request.getRating());
+
+        return ReviewDto.Response.builder()
+                .id(review.getId())
+                .storeId(review.getStore().getId())
+                .userId(review.getUser().getId())
+                .content(review.getContent())
+                .rating(review.getRating())
+                .createdAt(review.getCreatedAt())
+                .build();
     }
 }

--- a/src/test/java/com/zerobase/storereservation/service/ReviewServiceTest.java
+++ b/src/test/java/com/zerobase/storereservation/service/ReviewServiceTest.java
@@ -67,6 +67,7 @@ class ReviewServiceTest {
                 new ReviewDto.CreateRequest();
         request.setStoreId(1L);
         request.setUserId(1L);
+        request.setRating(3);
         request.setContent("Great Place");
 
         Review savedReview = Review.builder()
@@ -74,6 +75,7 @@ class ReviewServiceTest {
                 .store(store)
                 .user(user)
                 .content(request.getContent())
+                .rating(request.getRating())
                 .createdAt(LocalDateTime.now())
                 .build();
 
@@ -90,6 +92,60 @@ class ReviewServiceTest {
         assertEquals(1L, response.getStoreId());
         assertEquals(1L, response.getUserId());
         assertEquals(savedReview.getContent(), response.getContent());
+    }
+
+    @Test
+    @DisplayName("리뷰 등록 실패 - 유효하지 않은 평점")
+    void createReviewInvalidRating() {
+        //given
+        ReviewDto.CreateRequest request = new ReviewDto.CreateRequest();
+        request.setStoreId(1L);
+        request.setUserId(1L);
+        request.setContent("Invalid rating test");
+        request.setRating(6);
+
+        //when&then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> reviewService.createReview(request));
+        assertEquals(ErrorCode.INVALID_RATING, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("리뷰 등록 실패 - 존재하지 않는 매장")
+    void createReviewStoreNotFound() {
+        //given
+        when(storeRepository.findById(1L)).thenReturn(Optional.empty());
+
+        ReviewDto.CreateRequest request = new ReviewDto.CreateRequest();
+        request.setStoreId(1L);
+        request.setUserId(1L);
+        request.setRating(3);
+        request.setContent("Store not found test");
+
+        //when&then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> reviewService.createReview(request));
+        assertEquals(ErrorCode.STORE_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("리뷰 등록 실패 - 존재하지 않는 사용자")
+    void createReviewUserNotFound() {
+        //given
+        Store store = Store.builder().id(1L).build();
+        when(storeRepository.findById(1L)).thenReturn(Optional.of(store));
+        when(userRepository.findById(1L)).thenReturn(Optional.empty());
+
+        ReviewDto.CreateRequest request = new ReviewDto.CreateRequest();
+        request.setStoreId(1L);
+        request.setUserId(1L);
+        request.setRating(3);
+        request.setContent("User not found test");
+
+        //when&then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> reviewService.createReview(request));
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
     }
 
     @Test
@@ -139,29 +195,182 @@ class ReviewServiceTest {
     }
 
     @Test
-    @DisplayName("리뷰 삭제 성공")
-    void deleteReviewSuccess() {
+    @DisplayName("리뷰 삭제 성공 - 작성자가 삭제")
+    void deleteReviewSuccessByReviewer() {
         //given
-        when(reviewRepository.existsById(1L)).thenReturn(true);
+        Store store = Store.builder()
+                .id(1L)
+                .owner(User.builder().id(2L).build())
+                .build();
+
+        User user = User.builder()
+                .id(1L)
+                .username("Reviewer")
+                .build();
+
+        Review review = Review.builder()
+                .id(1L)
+                .store(store)
+                .user(user)
+                .content("Great Place")
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        when(reviewRepository.findById(1L)).thenReturn(Optional.of(review));
 
         //when
-        reviewService.deleteReview(1L);
+        reviewService.deleteReview(1L, 1L);
 
         //then
         verify(reviewRepository, times(1)).deleteById(1L);
     }
 
     @Test
-    @DisplayName("삭제할 리뷰가 없는 경우")
-    void deleteReviewNotFound() {
+    @DisplayName("리뷰 삭제 성공 - 매장 소유자가 삭제")
+    void deleteReviewSuccessByOwner() {
         //given
-        when(reviewRepository.findById(1L))
-                .thenReturn(Optional.empty());
+        Store store = Store.builder()
+                .id(1L)
+                .owner(User.builder().id(2L).build())
+                .build();
+
+        Review review = Review.builder()
+                .id(1L)
+                .store(store)
+                .user(User.builder().id(1L).build())
+                .content("Great Place")
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        when(reviewRepository.findById(1L)).thenReturn(Optional.of(review));
+
+        //when
+        reviewService.deleteReview(1L, 2L);
 
         //then
-        CustomException exception = assertThrows(
-                CustomException.class, () -> reviewService.deleteReview(1L)
-        );
-        assertEquals(REVIEW_NOT_FOUND, exception.getErrorCode());
+        verify(reviewRepository, times(1)).deleteById(1L);
+    }
+
+    @Test
+    @DisplayName("리뷰 삭제 실패 - 권한 없음")
+    void deleteReviewUnauthorized() {
+        //given
+        Store store = Store.builder()
+                .id(1L)
+                .owner(User.builder().id(2L).build())
+                .build();
+
+        Review review = Review.builder()
+                .id(1L)
+                .store(store)
+                .user(User.builder().id(1L).build())
+                .content("Great Place")
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        when(reviewRepository.findById(1L)).thenReturn(Optional.of(review));
+
+        //when&then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> reviewService.deleteReview(1L, 3L));
+        assertEquals(ErrorCode.UNAUTHORIZED_ACTION, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("리뷰 수정 성공")
+    void updateReviewSuccess() {
+        //given
+        User user = User.builder().id(1L).build();
+
+        Store store = Store.builder()
+                .id(1L)
+                .name("Test Store")
+                .build();
+
+        Review review = Review.builder()
+                .id(1L)
+                .user(user)
+                .store(store)
+                .content("Old Content")
+                .rating(3)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+
+        ReviewDto.UpdateRequest request = new ReviewDto.UpdateRequest();
+        request.setContent("Updated Content");
+        request.setRating(5);
+
+        when(reviewRepository.findById(1L)).thenReturn(Optional.of(review));
+        //when
+        ReviewDto.Response response =
+                reviewService.updateReview(1L, 1L, request);
+
+        //then
+        assertNotNull(response);
+        assertEquals(5, response.getRating());
+        assertEquals("Updated Content", response.getContent());
+    }
+
+    @Test
+    @DisplayName("리뷰 수정 실패 - 권한 없음")
+    void updateReviewUnauthorized() {
+        //given
+        Review review = Review.builder()
+                .id(1L)
+                .user(User.builder().id(1L).build())
+                .store(Store.builder().id(1L).build())
+                .content("Old Content")
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        ReviewDto.UpdateRequest request = new ReviewDto.UpdateRequest();
+        request.setContent("Updated Content");
+        request.setRating(5);
+
+        when(reviewRepository.findById(1L)).thenReturn(Optional.of(review));
+
+        //when&then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> reviewService.updateReview(1L, 2L, request));
+        assertEquals(ErrorCode.UNAUTHORIZED_ACTION, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("리뷰 조회 성공")
+    void getReviewByStoreSuccess() {
+        //given
+        Store store = Store.builder().id(1L).build();
+
+        Review review1 = Review.builder()
+                .id(1L)
+                .user(User.builder().id(1L).build())
+                .store(store)
+                .content("Great Place")
+                .rating(5)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        Review review2 = Review.builder()
+                .id(2L)
+                .user(User.builder().id(3L).build())
+                .store(store)
+                .content("test Review")
+                .rating(3)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        when(reviewRepository.findByStoreId(1L)).thenReturn(List.of(review1, review2));
+
+        //when
+        List<ReviewDto.Response> responses = reviewService.getReviewsByStore(1L);
+
+        //then
+        assertNotNull(responses);
+        assertEquals(2, responses.size());
+        assertEquals("Great Place", responses.get(0).getContent());
+        assertEquals(5, responses.get(0).getRating());
+        assertEquals("test Review", responses.get(1).getContent());
+        assertEquals(3, responses.get(1).getRating());
     }
 }


### PR DESCRIPTION
1. Review 엔티티 및 관련 기능 구현:
   - Review 엔티티: 작성자(User), 매장(Store), 내용(content), 평점(rating), 생성일(createdAt) 포함.
   - ReviewDto: CreateRequest, UpdateRequest, Response로 요청 및 응답 처리.
   - ReviewRepository: JPA 인터페이스로 DB 연동.

2. 리뷰 등록(Create):
   - 예약 사용자만 리뷰 작성 가능.
   - 평점은 1~5로 제한.
   - 등록 실패 상황:
     - 유효하지 않은 평점.
     - 존재하지 않는 매장 또는 사용자.

3. 리뷰 조회(Read):
   - 특정 매장의 모든 리뷰 조회 기능.
   - 매장 ID를 기준으로 리뷰 목록 반환.
   - 응답에 작성자 ID와 이름, 평점, 내용 포함.

4. 리뷰 수정(Update):
   - 작성자만 수정 가능.
   - 평점과 내용 수정 지원.
   - 수정 실패 상황:
     - 권한 없음.
     - 존재하지 않는 리뷰.

5. 리뷰 삭제(Delete):
   - 작성자와 매장 점주 모두 삭제 권한 보유.
   - 삭제 실패 상황:
     - 권한 없음.
     - 존재하지 않는 리뷰.

6. 테스트 코드 작성:
   - 단위 테스트: Mock 객체로 ReviewService 테스트.
   - 테스트 항목:
     - 성공 케이스: 등록, 조회, 수정, 삭제.
     - 실패 케이스: 평점 유효성, 권한 오류, 엔티티 없음.
   - 리뷰 목록 조회 시 응답 데이터의 순서 및 값 검증.

7. 기타:
   - 예외 처리 추가: `CustomException`과 `ErrorCode` 활용.
   - 컨트롤러 레벨에서 API 요청 처리 및 예외 매핑.